### PR TITLE
feat(helm): upgrade nginx chart dep and image to 2.2.1

### DIFF
--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -6,5 +6,5 @@ version: 2.5.0
 appVersion: 2.5.0
 dependencies:
   - name: nginx
-    version: 2.1.5
+    version: 2.2.1
     repository: oci://acrarolibotnonprod.azurecr.io/helm/common

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -62,6 +62,7 @@ env:
 nginx:
   enabled: true
   fullnameOverride: ""
+  nameOverride: "files-server-nginx"
   nginx:
     extensions:
       location:
@@ -72,7 +73,7 @@ nginx:
   replicaCount: 1
   image:
     repository: common/nginx
-    tag: "v2.1.5"
+    tag: "v2.2.1"
   port: 8080
   targetPort: 8080
   nodePort: 30003


### PR DESCRIPTION
## Summary
Upgrades the nginx dependency for the files-server helm chart (`helm/`).

- Bump nginx chart dependency `2.1.5` → `2.2.1` (`helm/Chart.yaml`)
- Bump nginx image tag `v2.1.5` → `v2.2.1` (`helm/values.yaml`)
- Add `nginx.nameOverride: "files-server-nginx"` (`helm/values.yaml`)