### PR TITLE
fix(helm): upgrade nginx chart to 2.3.1 and drop pinned image tag

### DIFF
--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -6,5 +6,5 @@ version: 2.6.0
 appVersion: 2.6.0
 dependencies:
   - name: nginx
-    version: 2.2.1
+    version: 2.3.1
     repository: oci://acrarolibotnonprod.azurecr.io/helm/common

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -73,6 +73,7 @@ nginx:
   replicaCount: 1
   image:
     repository: common/nginx
+    tag: "v2.3.1"
   port: 8080
   targetPort: 8080
   nodePort: 30003

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -73,7 +73,6 @@ nginx:
   replicaCount: 1
   image:
     repository: common/nginx
-    tag: "v2.2.1"
   port: 8080
   targetPort: 8080
   nodePort: 30003

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -73,7 +73,6 @@ nginx:
   replicaCount: 1
   image:
     repository: common/nginx
-    tag: "v2.3.1"
   port: 8080
   targetPort: 8080
   nodePort: 30003


### PR DESCRIPTION
## Description

- Upgrade the `nginx` chart dependency in `helm/Chart.yaml` from 2.2.1 to 2.3.1.
- Remove the pinned `nginx.image.tag` from `helm/values.yaml` so the image tag falls back to the chart's default.